### PR TITLE
Add Persistent Class Decorator and Unpickling Utilities and Fix minor bugs

### DIFF
--- a/src/inversion/Image2StyleGAN.py
+++ b/src/inversion/Image2StyleGAN.py
@@ -28,6 +28,7 @@ import legacy
 from src.utils import align_image
 from src.morphing import VGG16_perceptual
 from ffhq_dataset.landmarks_detector import LandmarksDetector
+from src import dnnlib
 
 
 device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
@@ -156,7 +157,7 @@ def projection(network_pkl, num_steps, input_image, output_dir, seed=303):
 
     image = input_image
     output_dir = output_dir + "/"
-    with src.dnnlib.util.open_url(network_pkl) as fp:
+    with dnnlib.util.open_url(network_pkl) as fp:
         # Load networks.
         print('Loading networks from "%s"...' % network_pkl)
         G = legacy.load_network_pkl(fp)['G_ema'].requires_grad_(False).to(device) # type: ignore
@@ -203,7 +204,7 @@ def run_projection(network_pkl: str, seed: int, num_steps: int, input_image: str
 
     image = input_image
     output_dir = output_dir + "/"
-    with src.dnnlib.util.open_url(network_pkl) as fp:
+    with dnnlib.util.open_url(network_pkl) as fp:
         # Load networks.
         print('Loading networks from "%s"...' % network_pkl)
         G = legacy.load_network_pkl(fp)['G_ema'].requires_grad_(False).to(device) # type: ignore

--- a/src/inversion/Image2StyleGAN.py
+++ b/src/inversion/Image2StyleGAN.py
@@ -197,6 +197,7 @@ def projection(network_pkl, num_steps, input_image, output_dir, seed=303):
 @click.option('--input_image',            help='Image to Invert', type=str, default="input/04203d523.jpg")
 @click.option('--output_dir',             help='Output Folder for Latent and Reconstructed Image', type=str, default="output")
 
+
 def run_projection(network_pkl: str, seed: int, num_steps: int, input_image: str, output_dir: str):
 
     np.random.seed(seed)

--- a/src/inversion/landmark_inverter.py
+++ b/src/inversion/landmark_inverter.py
@@ -101,5 +101,8 @@ def landmark_inversion_warping(img1: str, img2: str, network_pkl: str, num_steps
 
     latent_morpher(network_pkl, l1, l2, morph_coeffs, output_dir + "/morphed_masks")
 
+    # Paste Morphed Mask
+    paste_images(aligned1, aligned2, morphed_mask,
+                 warped1.replace("warped", "morphed"),
+                 warped2.replace("warped", "morphed"))
 
-    return

--- a/src/main.py
+++ b/src/main.py
@@ -96,6 +96,7 @@ def main():
 
     args = parser.parse_args()
 
+
     # Suppress specific warnings
     warnings.filterwarnings("ignore", message="Failed to build CUDA kernels for upfirdn2d")
     warnings.filterwarnings("ignore", category=UserWarning)

--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ def main():
     parser = argparse.ArgumentParser(description="StyleGAN Morphing Tool")
 
     # Command-line arguments
-    parser.add_argument('--list', type=str, default="./examples/morph_pairs.txt", help="Path to the list of morph pairs.")
+    parser.add_argument('--list', type=str, default="../examples/morph_pairs.txt", help="Path to the list of morph pairs.")
     parser.add_argument('--method', type=str, choices=["StyleGAN", "OpenCV", "FaceMorpher"], default="StyleGAN",
                         help="Morph synthesis method to use.")
     parser.add_argument('--inversion', type=str, choices=["I2S", "Landmark"], default="I2S", help="Inversion method to use.")

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -165,3 +165,23 @@ def _module_to_src(module):
         _module_to_src_dict[module] = src
         _src_to_module_dict[src] = module
     return src
+
+def _src_to_module(src):
+    """
+    Create or retrieve a Python module for a given source code.
+
+    Args:
+        src (str): Source code of the module.
+
+    Returns:
+        module: Python module object.
+    """
+    module = _src_to_module_dict.get(src, None)
+    if module is None:
+        module_name = "_imported_module_" + uuid.uuid4().hex
+        module = types.ModuleType(module_name)
+        sys.modules[module_name] = module
+        _module_to_src_dict[module] = src
+        _src_to_module_dict[src] = module
+        exec(src, module.__dict__)
+    return module

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -28,3 +28,64 @@ _decorators = set()  # Set of decorator classes
 _import_hooks = []  # List of import hook functions
 _module_to_src_dict = dict()  # Mapping of modules to source code
 _src_to_module_dict = dict()  # Mapping of source code to modules
+
+def persistent_class(orig_class):
+    """
+    Class decorator to make a Python class persistent by saving its source code when pickled.
+
+    Args:
+        orig_class (type): The original class to be decorated.
+
+    Returns:
+        type: Decorated class with persistence capabilities.
+    """
+    assert isinstance(orig_class, type)
+
+    if is_persistent(orig_class):
+        return orig_class
+
+    assert orig_class.__module__ in sys.modules
+    orig_module = sys.modules[orig_class.__module__]
+    orig_module_src = _module_to_src(orig_module)
+
+    class Decorator(orig_class):
+        _orig_module_src = orig_module_src
+        _orig_class_name = orig_class.__name__
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._init_args = copy.deepcopy(args)
+            self._init_kwargs = copy.deepcopy(kwargs)
+            assert orig_class.__name__ in orig_module.__dict__
+            _check_pickleable(self.__reduce__())
+
+        @property
+        def init_args(self):
+            """Get the initialization arguments of the instance."""
+            return copy.deepcopy(self._init_args)
+
+        @property
+        def init_kwargs(self):
+            """Get the initialization keyword arguments of the instance."""
+            return dnnlib.EasyDict(copy.deepcopy(self._init_kwargs))
+
+        def __reduce__(self):
+            """Customize object reduction for pickling."""
+            fields = list(super().__reduce__())
+            fields += [None] * max(3 - len(fields), 0)
+            if fields[0] is not _reconstruct_persistent_obj:
+                meta = {
+                    'type': 'class',
+                    'version': _version,
+                    'module_src': self._orig_module_src,
+                    'class_name': self._orig_class_name,
+                    'state': fields[2]
+                }
+                fields[0] = _reconstruct_persistent_obj  # Reconstruction function
+                fields[1] = (meta,)  # Reconstruction arguments
+                fields[2] = None  # State dictionary
+            return tuple(fields)
+
+    Decorator.__name__ = orig_class.__name__
+    _decorators.add(Decorator)
+    return Decorator

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -148,3 +148,20 @@ def _reconstruct_persistent_obj(meta):
     else:
         obj.__dict__.update(meta.state)
     return obj
+
+def _module_to_src(module):
+    """
+    Retrieve the source code of a Python module.
+
+    Args:
+        module: Python module.
+
+    Returns:
+        str: Source code of the module.
+    """
+    src = _module_to_src_dict.get(module, None)
+    if src is None:
+        src = inspect.getsource(module)
+        _module_to_src_dict[module] = src
+        _src_to_module_dict[src] = module
+    return src

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -12,3 +12,19 @@ The pickled code is automatically imported into a separate Python module
 during unpickling. This way, any previously exported pickles will remain
 usable even if the original code is no longer available, or if the current
 version of the code is not consistent with what was originally pickled."""
+
+import sys
+import pickle
+import io
+import inspect
+import copy
+import uuid
+import types
+import dnnlib
+
+# Internal versioning and tracking variables
+_version = 6  # Internal version number
+_decorators = set()  # Set of decorator classes
+_import_hooks = []  # List of import hook functions
+_module_to_src_dict = dict()  # Mapping of modules to source code
+_src_to_module_dict = dict()  # Mapping of source code to modules

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+"""Facilities for pickling Python code alongside other data.
+
+The pickled code is automatically imported into a separate Python module
+during unpickling. This way, any previously exported pickles will remain
+usable even if the original code is no longer available, or if the current
+version of the code is not consistent with what was originally pickled."""

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -89,3 +89,20 @@ def persistent_class(orig_class):
     Decorator.__name__ = orig_class.__name__
     _decorators.add(Decorator)
     return Decorator
+
+def is_persistent(obj):
+    """
+    Check if an object or class is persistent.
+
+    Args:
+        obj: Object or class to check.
+
+    Returns:
+        bool: True if the object or class is persistent, False otherwise.
+    """
+    try:
+        if obj in _decorators:
+            return True
+    except TypeError:
+        pass
+    return type(obj) in _decorators

--- a/src/torch_utils/persistence.py
+++ b/src/torch_utils/persistence.py
@@ -106,3 +106,13 @@ def is_persistent(obj):
     except TypeError:
         pass
     return type(obj) in _decorators
+
+def import_hook(hook):
+    """
+    Register an import hook to modify pickled source code during unpickling.
+
+    Args:
+        hook (callable): Function to be called during unpickling.
+    """
+    assert callable(hook)
+    _import_hooks.append(hook)


### PR DESCRIPTION
This PR introduces a set of utilities to enable the persistence of Python classes by saving their source code when pickled. The primary additions include:

- Fix minor bugs and improve code stability

- `persistent_class` **Decorator**: A class decorator to serialize and deserialize classes with their source code, ensuring compatibility across code changes or missing definitions.

- **Import Hooks**: Mechanisms to modify and handle pickled source code during unpickling, accommodating API changes or enhancements.

- **Utilities for Source Code Management**: Functions to extract and manage module source code (`_module_to_src`, _src_to_module) to facilitate reconstruction of persistent objects.